### PR TITLE
Fix TypeError in GSAP onComplete callback

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -57,7 +57,12 @@ class App {
         
         window.addEventListener('resize', this.onResize.bind(this));
         this.animate();
-        gsap.to('#loading-screen', { opacity: 0, duration: 1.5, onComplete: (el) => el.style.display = 'none' });
+        gsap.to('#loading-screen', { opacity: 0, duration: 1.5, onComplete: () => {
+            const el = document.querySelector('#loading-screen');
+            if (el) {
+                el.style.display = 'none';
+            }
+        }});
         console.log("Interstellar Experience Initialized. All systems nominal.");
     }
 


### PR DESCRIPTION
The `onComplete` callback for the loading screen animation was causing a `TypeError` because it incorrectly tried to access the `style` property of an undefined parameter.

This commit fixes the issue by modifying the callback to use `document.querySelector` to reliably select the `#loading-screen` element. It also adds a null check to prevent errors in case the element is not found, making the code more robust.